### PR TITLE
clickhouse-driver 0.2.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,11 +26,9 @@ requirements:
     - setuptools
     - wheel
   run:
-    # 6/7/2021: Drop support Python 2.7
     - python
-    - six
     - pytz
-    - tzlocal <3.0
+    - tzlocal
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "clickhouse-driver" %}
-{% set version = "0.2.1" %}
-{% set sha256 = "8f446bdc38a676d4b345a4395cf913e47d1a694250a971ddd50c24e08029fc75" %}
+{% set version = "0.2.7" %}
+{% set sha256 = "299cfbe6d561955d88eeab6e09f3de31e2f6daccc6fdd904a59e46357d2d28d9" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
+  skip: True  # [py<37]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [py<37]
 
 requirements:
@@ -49,6 +49,7 @@ about:
   dev_url: https://github.com/mymarilyn/clickhouse-driver
   license: MIT
   summary: Python driver with native interface for ClickHouse
+  description: ClickHouse Python Driver with native interface support
   license_family: MIT
   license_file: LICENSE
 


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4680](https://anaconda.atlassian.net/browse/PKG-4680)
- [Upstream repository](https://github.com/mymarilyn/clickhouse-driver/tree/0.2.7)
- [Upstream changelog/diff](https://github.com/mymarilyn/clickhouse-driver/blob/0.2.7/CHANGELOG.md)

### Explanation of changes:

- Update version
- Skip < python 3.7
- Dependency updates
- Linter fixes


[PKG-4680]: https://anaconda.atlassian.net/browse/PKG-4680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ